### PR TITLE
Adds referrer instructions and fixes ser/des of static length strings on accounts

### DIFF
--- a/Solnet.Mango.Test/InstructionDecodingTest.cs
+++ b/Solnet.Mango.Test/InstructionDecodingTest.cs
@@ -50,6 +50,10 @@ namespace Solnet.Mango.Test
 
         private const string RemoveAdvancedOrderMessage = "AQAEBgpz5x/t0hNl7QruhPzk4rIGR/001ey9oRXwI9JjP4d4rQqXXruIOVtp8L9IgE6vrVLzYNobX3u6/Rbj/+6kqIjKISAtTF7lMdQarmxDZG/wXw1EdsMrRmiMvKrmbhkiIVTo0h0JftHn9tx6NSAOOqytyt4VksgHKcuqfxgcBhksAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5kw4m3RTlrY1U1TDoqPHph4SQpWHgwU5NDOx8pbUuMVy7776PgCLScUwD+RHspt3GxeMeP3YLDofTNwAmOLb5AgUFAgMAAQQFLAAAAAAFBQIDAAEEBSwAAAAB";
 
+        private const string RegisterReferrerIdMessage = "AQADBgpz5x/t0hNl7QruhPzk4rIGR/001ey9oRXwI9JjP4d4VOjSHQl+0ef23Ho1IA46rK3K3hWSyAcpy6p/GBwGGSyOp6NBx6ory8mCYmEEOJfjeV5Cnluo6hqEWgoNXV0QIMohIC1MXuUx1BqubENkb/BfDUR2wytGaIy8quZuGSIhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5kw4m3RTlrY1U1TDoqPHph4SQpWHgwU5NDOx8pbUuMfzcPp0NtGiciNbubOEdIMRdL8iIdgd6VlVb297cJPymAQUFAwECAAQkPwAAAAsAAAAAAAAATWFuZ28gU2hhcnAAAAAAAAAAAAAAAAAA";
+
+        private const string CreateAddInfoAndSetReferrerMessage = "AQADBwpz5x/t0hNl7QruhPzk4rIGR/001ey9oRXwI9JjP4d4yiEgLUxe5THUGq5sQ2Rv8F8NRHbDK0ZojLyq5m4ZIiFUuwWRySJQNgY58mxU+b8uVIuhNTll53Dwl92OZZe3JkTFd9tOlil5/rnLZPD7yWlc3nbyadEvaHdN1aiMKRWiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5kw4m3RTlrY1U1TDoqPHph4SQpWHgwU5NDOx8pbUuMZgDGKDYUS/Ky0lGSOvWR+S/EaL8QpMvVBpkUNVmt9okws4NuTwmaDTUgOHsTuXuQqpZ4EMZU8FTWTackpIQdPoDBQQBAgAEDDcAAAAEAAAAAAAAAAUDAQIAJCIAAABNYW5nbyBTaGFycCBSZWYgVGVzdAAAAAAAAAAAAAAAAAUHAQIAAwYABAQ+AAAA";
+
         [ClassInitialize]
         public static void Setup(TestContext tc)
         {
@@ -79,7 +83,7 @@ namespace Solnet.Mango.Test
             Assert.AreEqual("Ec2enZyoC4nGpEfu2sUNAa2nUGJHWxoUWYSEJ2hNTWTA", ix[2].Values.GetValueOrDefault("Mango Group").ToString());
             Assert.AreEqual("EEoHecXUMTx5omC1cTHDuv7VKGTmzq8M5d86GnBHYMPS", ix[2].Values.GetValueOrDefault("Mango Account").ToString());
             Assert.AreEqual("hoakwpFB8UoLnPpLC56gsjpY7XbVwaCuRQRMQzN5TVh", ix[2].Values.GetValueOrDefault("Owner").ToString());
-            Assert.AreEqual("Solnet Test v1", ix[2].Values.GetValueOrDefault("Account Info"));
+            Assert.AreEqual("\0\0\0\0\0\0\0Solnet Test v1", ix[2].Values.GetValueOrDefault("Account Info"));
         }
 
         [TestMethod]
@@ -103,7 +107,7 @@ namespace Solnet.Mango.Test
             Assert.AreEqual("Ec2enZyoC4nGpEfu2sUNAa2nUGJHWxoUWYSEJ2hNTWTA", ix[1].Values.GetValueOrDefault("Mango Group").ToString());
             Assert.AreEqual("BEPi5vEzwwY5SDfzxWsVQiK7ApuTE3doJkYUVGqAoX2s", ix[1].Values.GetValueOrDefault("Mango Account").ToString());
             Assert.AreEqual("hoakwpFB8UoLnPpLC56gsjpY7XbVwaCuRQRMQzN5TVh", ix[1].Values.GetValueOrDefault("Owner").ToString());
-            Assert.AreEqual("Solnet Test v1", ix[1].Values.GetValueOrDefault("Account Info"));
+            Assert.AreEqual("\0\0\0\0\0\0\0Solnet Test v1", ix[1].Values.GetValueOrDefault("Account Info"));
         }
 
         [TestMethod]
@@ -612,6 +616,45 @@ namespace Solnet.Mango.Test
             Assert.AreEqual("0", ix[0].Values.GetValueOrDefault("Order Index").ToString());
             Assert.AreEqual("Remove Advanced Order", ix[1].InstructionName);
             Assert.AreEqual("1", ix[1].Values.GetValueOrDefault("Order Index").ToString());
+        }
+
+        [TestMethod]
+        public void CreateAddInfoAndSetReferral()
+        {
+            Message msg = Message.Deserialize(Convert.FromBase64String(CreateAddInfoAndSetReferrerMessage));
+            List<DecodedInstruction> ix =
+                InstructionDecoder.DecodeInstructions(msg);
+
+            Assert.AreEqual(3, ix.Count);
+            Assert.AreEqual("Mango Program V3", ix[2].ProgramName);
+            Assert.AreEqual("Set Referrer Memory", ix[2].InstructionName);
+            Assert.AreEqual(0, ix[2].InnerInstructions.Count);
+            Assert.AreEqual("Ec2enZyoC4nGpEfu2sUNAa2nUGJHWxoUWYSEJ2hNTWTA", ix[2].Values.GetValueOrDefault("Mango Group").ToString());
+            Assert.AreEqual("6hkegFv9bCeKpKJdvhJwbmrKyAAeDS3vkkWC5RHeBWUM", ix[2].Values.GetValueOrDefault("Mango Account").ToString());
+            Assert.AreEqual("hoakwpFB8UoLnPpLC56gsjpY7XbVwaCuRQRMQzN5TVh", ix[2].Values.GetValueOrDefault("Owner").ToString());
+            Assert.AreEqual("5dTNBvZcxPP6p989uXZZZAasUCRYne9x5fnnVLTB3rND", ix[2].Values.GetValueOrDefault("Referrer Memory").ToString());
+            Assert.AreEqual("BEPi5vEzwwY5SDfzxWsVQiK7ApuTE3doJkYUVGqAoX2s", ix[2].Values.GetValueOrDefault("Referrer Mango Account").ToString());
+            Assert.AreEqual("hoakwpFB8UoLnPpLC56gsjpY7XbVwaCuRQRMQzN5TVh", ix[2].Values.GetValueOrDefault("Payer").ToString());
+            Assert.AreEqual(SystemProgram.ProgramIdKey, ix[2].Values.GetValueOrDefault("System Program").ToString());
+        }
+
+        [TestMethod]
+        public void RegisterReferrerId()
+        {
+            Message msg = Message.Deserialize(Convert.FromBase64String(RegisterReferrerIdMessage));
+            List<DecodedInstruction> ix =
+                InstructionDecoder.DecodeInstructions(msg);
+
+            Assert.AreEqual(1, ix.Count);
+            Assert.AreEqual("Mango Program V3", ix[0].ProgramName);
+            Assert.AreEqual("Register Referrer Id", ix[0].InstructionName);
+            Assert.AreEqual(0, ix[0].InnerInstructions.Count);
+            Assert.AreEqual("Ec2enZyoC4nGpEfu2sUNAa2nUGJHWxoUWYSEJ2hNTWTA", ix[0].Values.GetValueOrDefault("Mango Group").ToString());
+            Assert.AreEqual("6iT9xdeMXqytgCpKqicPMJRCDk59mv7GYBSZkQAAP7R5", ix[0].Values.GetValueOrDefault("Referrer Mango Account").ToString());
+            Assert.AreEqual("Abs9roAyf35gb7xf7FTMoxfGviLMGQpMdVhydpDmcJFR", ix[0].Values.GetValueOrDefault("Referrer Id Record").ToString());
+            Assert.AreEqual("hoakwpFB8UoLnPpLC56gsjpY7XbVwaCuRQRMQzN5TVh", ix[0].Values.GetValueOrDefault("Payer").ToString());
+            Assert.AreEqual(SystemProgram.ProgramIdKey, ix[0].Values.GetValueOrDefault("System Program").ToString());
+            Assert.AreEqual("\v\0\0\0\0\0\0\0Mango Sharp", ix[0].Values.GetValueOrDefault("Referrer Id").ToString());
         }
     }
 }

--- a/Solnet.Mango.Test/MangoClientStreamingTest.cs
+++ b/Solnet.Mango.Test/MangoClientStreamingTest.cs
@@ -457,7 +457,7 @@ namespace Solnet.Mango.Test
             Assert.IsFalse(resultNotification.Bankrupt);
             Assert.IsFalse(resultNotification.BeingLiquidated);
             Assert.IsFalse(resultNotification.NotUpgradeable);
-            Assert.AreEqual("Solnet Test v1", resultNotification.AccountInfo);
+            Assert.AreEqual("\0\0\0\0\0\0\0Solnet Test v1", resultNotification.AccountInfo);
             Assert.AreEqual(SystemProgram.ProgramIdKey, resultNotification.Delegate);
             Assert.AreEqual(Constants.DevNetMangoGroup, resultNotification.MangoGroup);
             Assert.AreEqual("hoakwpFB8UoLnPpLC56gsjpY7XbVwaCuRQRMQzN5TVh", resultNotification.Owner);
@@ -526,7 +526,7 @@ namespace Solnet.Mango.Test
             Assert.IsFalse(resultNotification.Bankrupt);
             Assert.IsFalse(resultNotification.BeingLiquidated);
             Assert.IsFalse(resultNotification.NotUpgradeable);
-            Assert.AreEqual("Solnet Test v1", resultNotification.AccountInfo);
+            Assert.AreEqual("\0\0\0\0\0\0\0Solnet Test v1", resultNotification.AccountInfo);
             Assert.AreEqual(SystemProgram.ProgramIdKey, resultNotification.Delegate);
             Assert.AreEqual(Constants.DevNetMangoGroup, resultNotification.MangoGroup);
             Assert.AreEqual("hoakwpFB8UoLnPpLC56gsjpY7XbVwaCuRQRMQzN5TVh", resultNotification.Owner);

--- a/Solnet.Mango.Test/MangoClientTest.cs
+++ b/Solnet.Mango.Test/MangoClientTest.cs
@@ -352,7 +352,7 @@ namespace Solnet.Mango.Test
             Assert.IsFalse(mangoAccount.ParsedResult.Bankrupt);
             Assert.IsFalse(mangoAccount.ParsedResult.BeingLiquidated);
             Assert.IsFalse(mangoAccount.ParsedResult.NotUpgradeable);
-            Assert.AreEqual("Solnet Test v1", mangoAccount.ParsedResult.AccountInfo);
+            Assert.AreEqual("\0\0\0\0\0\0\0Solnet Test v1", mangoAccount.ParsedResult.AccountInfo);
             Assert.AreEqual(SystemProgram.ProgramIdKey, mangoAccount.ParsedResult.Delegate);
             Assert.AreEqual(Constants.DevNetMangoGroup, mangoAccount.ParsedResult.MangoGroup);
             Assert.AreEqual("hoakwpFB8UoLnPpLC56gsjpY7XbVwaCuRQRMQzN5TVh", mangoAccount.ParsedResult.Owner);
@@ -566,6 +566,39 @@ namespace Solnet.Mango.Test
             Assert.AreEqual(DataType.Asks, obs.ParsedResult.Metadata.DataType);
             var asks = obs.ParsedResult.GetOrders();
             Assert.AreEqual(8, asks.Count);
+        }
+
+        [TestMethod]
+        public void GetReferrerMemory()
+        {
+            string response = File.ReadAllText("Resources/MangoClient/GetReferrerMemoryAccountInfo.json");
+            var rpc = SetupGetAccountInfo(response, "CieTZBNze2T4FqzG6s4uRjQcekuV7EqK1qSWMnK7FjUZ", "https://api.devnet.solana.com");
+
+            var mangoClient = ClientFactory.GetClient(rpc.Object);
+
+            var referrer = mangoClient.GetReferrerMemoryAccount(new("CieTZBNze2T4FqzG6s4uRjQcekuV7EqK1qSWMnK7FjUZ"));
+
+            Assert.IsNotNull(referrer);
+            Assert.IsTrue(referrer.ParsedResult.Metadata.IsInitialized);
+            Assert.AreEqual(DataType.ReferrerMemory, referrer.ParsedResult.Metadata.DataType);
+            Assert.AreEqual("BEPi5vEzwwY5SDfzxWsVQiK7ApuTE3doJkYUVGqAoX2s", referrer.ParsedResult.Referrer);
+        }
+
+        [TestMethod]
+        public void GetReferrerIdRecord()
+        {
+            string response = File.ReadAllText("Resources/MangoClient/GetReferrerIdRecordAccountInfo.json");
+            var rpc = SetupGetAccountInfo(response, "98wPi7vBkiJ1sXLPipQEjrgHYcMBcNUsg9avTyWUi26j", "https://api.devnet.solana.com");
+
+            var mangoClient = ClientFactory.GetClient(rpc.Object);
+
+            var referrer = mangoClient.GetReferrerIdRecordAccount(new("98wPi7vBkiJ1sXLPipQEjrgHYcMBcNUsg9avTyWUi26j"));
+
+            Assert.IsNotNull(referrer);
+            Assert.IsTrue(referrer.ParsedResult.Metadata.IsInitialized);
+            Assert.AreEqual(DataType.ReferrerIdRecord, referrer.ParsedResult.Metadata.DataType);
+            Assert.AreEqual("\n\0\0\0\0\0\0\0Hoak Sharp", referrer.ParsedResult.Id);
+            Assert.AreEqual("BEPi5vEzwwY5SDfzxWsVQiK7ApuTE3doJkYUVGqAoX2s", referrer.ParsedResult.Referrer);
         }
 
         [TestMethod]

--- a/Solnet.Mango.Test/MangoProgramTest.cs
+++ b/Solnet.Mango.Test/MangoProgramTest.cs
@@ -74,6 +74,25 @@ namespace Solnet.Mango.Test
         }
 
         [TestMethod]
+        public void DeriveMainNetReferrerIdRecord()
+        {
+            var mango = MangoProgram.CreateMainNet();
+            var referrerIdRecord = mango.DeriveReferrerIdRecord("MangoSharp");
+
+            Assert.AreEqual("Bv5tz9AzgkpPCmsDVYAA5aM9tUncZbhLCESiWSmYB5en", referrerIdRecord);
+        }
+        
+
+        [TestMethod]
+        public void DeriveDevNetReferrerIdRecord()
+        {
+            var mango = MangoProgram.CreateDevNet();
+            var referrerIdRecord = mango.DeriveReferrerIdRecord("MangoSharp");
+
+            Assert.AreEqual("2SVASRV7NXFJSZQKdH3PYAphtMezXLFd2VDpfDifJ777", referrerIdRecord);
+        }
+
+        [TestMethod]
         public void InitializeMangoAccount()
         {
             var mango = MangoProgram.CreateDevNet();
@@ -1004,10 +1023,9 @@ namespace Solnet.Mango.Test
                 );
             var expectedData = new byte[] 
             { 
-                34, 0, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0,
-                83, 111, 108, 110, 101, 116, 32, 84, 101,
+                34, 0, 0, 0, 83, 111, 108, 110, 101, 116, 32, 84, 101,
                 115, 116, 32, 118, 49, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             };
             Assert.AreEqual(3, ix.Keys.Count);
             CollectionAssert.AreEqual(Encoders.Base58.DecodeData(MangoProgram.DevNetProgramIdKeyV3), ix.ProgramId);

--- a/Solnet.Mango.Test/Resources/MangoClient/GetReferrerIdRecordAccountInfo.json
+++ b/Solnet.Mango.Test/Resources/MangoClient/GetReferrerIdRecordAccountInfo.json
@@ -1,0 +1,10 @@
+{
+  "context": { "slot": 115286167 },
+  "value": {
+    "data": [ "CwABAAAAAACYAxig2FEvystJRkjr1kfkvxGi/EKTL1QaZFDVZrfaJAoAAAAAAAAASG9hayBTaGFycAAAAAAAAAAAAAAAAAAA", "base64" ],
+    "executable": false,
+    "lamports": 1392000,
+    "owner": "4skJ85cdxQAFVKbcGgfun8iZPL7BadVYXG3kGEGkufqA",
+    "rentEpoch": 266
+  }
+}

--- a/Solnet.Mango.Test/Resources/MangoClient/GetReferrerMemoryAccountInfo.json
+++ b/Solnet.Mango.Test/Resources/MangoClient/GetReferrerMemoryAccountInfo.json
@@ -1,0 +1,10 @@
+{
+  "context": { "slot": 115286898 },
+  "value": {
+    "data": [ "CgABAAAAAACYAxig2FEvystJRkjr1kfkvxGi/EKTL1QaZFDVZrfaJA==", "base64" ],
+    "executable": false,
+    "lamports": 1169280,
+    "owner": "4skJ85cdxQAFVKbcGgfun8iZPL7BadVYXG3kGEGkufqA",
+    "rentEpoch": 266
+  }
+}

--- a/Solnet.Mango.Test/Solnet.Mango.Test.csproj
+++ b/Solnet.Mango.Test/Solnet.Mango.Test.csproj
@@ -166,6 +166,12 @@
       <None Update="Resources\MangoClient\GetPerpMarketAccountInfo.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="Resources\MangoClient\GetReferrerIdRecordAccountInfo.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="Resources\MangoClient\GetReferrerMemoryAccountInfo.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
       <None Update="Resources\MangoClient\GetRootBankAccountInfo.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>

--- a/Solnet.Mango/IMangoClient.cs
+++ b/Solnet.Mango/IMangoClient.cs
@@ -304,6 +304,38 @@ namespace Solnet.Mango
             Commitment commitment = Commitment.Finalized);
 
         /// <summary>
+        /// Gets the given referrer memory. This is an asynchronous operation.
+        /// </summary>
+        /// <param name="referrerMemory">The referrer memory.</param>
+        /// <param name="commitment">The confirmation commitment parameter for the RPC call.</param>
+        /// <returns>The <see cref="ReferrerMemoryAccount"/> or null in case an error occurred.</returns>
+        Task<AccountResultWrapper<ReferrerMemoryAccount>> GetReferrerMemoryAccountAsync(PublicKey referrerMemory, Commitment commitment = Commitment.Finalized);
+
+        /// <summary>
+        /// Gets the given referrer memory.
+        /// </summary>
+        /// <param name="referrerMemory">The referrer memory.</param>
+        /// <param name="commitment">The confirmation commitment parameter for the RPC call.</param>
+        /// <returns>The <see cref="ReferrerMemoryAccount"/> or null in case an error occurred.</returns>
+        AccountResultWrapper<ReferrerMemoryAccount> GetReferrerMemoryAccount(PublicKey referrerMemory, Commitment commitment = Commitment.Finalized);
+
+        /// <summary>
+        /// Gets the given referrer id record. This is an asynchronous operation.
+        /// </summary>
+        /// <param name="referrerIdRecord">The referrer id record.</param>
+        /// <param name="commitment">The confirmation commitment parameter for the RPC call.</param>
+        /// <returns>The <see cref="ReferrerIdRecordAccount"/> or null in case an error occurred.</returns>
+        Task<AccountResultWrapper<ReferrerIdRecordAccount>> GetReferrerIdRecordAccountAsync(PublicKey referrerIdRecord, Commitment commitment = Commitment.Finalized);
+
+        /// <summary>
+        /// Gets the given referrer id record.
+        /// </summary>
+        /// <param name="referrerIdRecord">The referrer id record.</param>
+        /// <param name="commitment">The confirmation commitment parameter for the RPC call.</param>
+        /// <returns>The <see cref="ReferrerIdRecordAccount"/> or null in case an error occurred.</returns>
+        AccountResultWrapper<ReferrerIdRecordAccount> GetReferrerIdRecordAccount(PublicKey referrerIdRecord, Commitment commitment = Commitment.Finalized);
+
+        /// <summary>
         /// Subscribe to a live feed of an <see cref="EventQueue"/>. This is an asynchronous operation.
         /// </summary>
         /// <param name="action">An action which receives the <see cref="Subscription"/>, an <see cref="EventQueue"/> and the corresponding slot.</param>

--- a/Solnet.Mango/MangoClient.cs
+++ b/Solnet.Mango/MangoClient.cs
@@ -221,6 +221,24 @@ namespace Solnet.Mango
         public AccountResultWrapper<MangoAccount> GetMangoAccount(string account, Commitment commitment = Commitment.Finalized)
             => GetMangoAccountAsync(account, commitment).Result;
 
+        /// <inheritdoc cref="IMangoClient.GetReferrerMemoryAccountAsync(PublicKey, Commitment)"/>
+        public async Task<AccountResultWrapper<ReferrerMemoryAccount>> GetReferrerMemoryAccountAsync(PublicKey referrerMemory,
+            Commitment commitment = Commitment.Finalized)
+            => await GetAccount<ReferrerMemoryAccount>(referrerMemory, commitment);
+
+        /// <inheritdoc cref="IMangoClient.GetReferrerMemoryAccount(PublicKey,Commitment)"/>
+        public AccountResultWrapper<ReferrerMemoryAccount> GetReferrerMemoryAccount(PublicKey referrerMemory, Commitment commitment = Commitment.Finalized)
+            => GetReferrerMemoryAccountAsync(referrerMemory, commitment).Result;
+
+        /// <inheritdoc cref="IMangoClient.GetReferrerIdRecordAccountAsync(PublicKey, Commitment)"/>
+        public async Task<AccountResultWrapper<ReferrerIdRecordAccount>> GetReferrerIdRecordAccountAsync(PublicKey referrerIdRecord,
+            Commitment commitment = Commitment.Finalized)
+            => await GetAccount<ReferrerIdRecordAccount>(referrerIdRecord, commitment);
+
+        /// <inheritdoc cref="IMangoClient.GetReferrerIdRecordAccount(PublicKey,Commitment)"/>
+        public AccountResultWrapper<ReferrerIdRecordAccount> GetReferrerIdRecordAccount(PublicKey referrerIdRecord, Commitment commitment = Commitment.Finalized)
+            => GetReferrerIdRecordAccountAsync(referrerIdRecord, commitment).Result;
+
         /// <inheritdoc cref="IMangoClient.GetAdvancedOrdersAccountAsync(string,Commitment)"/>
         public async Task<AccountResultWrapper<AdvancedOrdersAccount>> GetAdvancedOrdersAccountAsync(string account,
             Commitment commitment = Commitment.Finalized)

--- a/Solnet.Mango/MangoProgram.cs
+++ b/Solnet.Mango/MangoProgram.cs
@@ -1549,21 +1549,132 @@ namespace Solnet.Mango
         }
 
         /// <summary>
+        /// Initialize a new <see cref="TransactionInstruction"/> for the <see cref="MangoProgramInstructions.Values.SetReferrerMemory"/> method.
+        /// </summary>
+        /// <param name="mangoGroup">The mango group.</param>
+        /// <param name="mangoAccount">The mango account.</param>
+        /// <param name="owner">The mango account owner.</param>
+        /// <param name="referrerMemory">The referrer memory PDA.</param>
+        /// <param name="referrerMangoAccount">The referrer's mango account.</param>
+        /// <param name="payer">The payer of the rent for the new <see cref="ReferrerMemoryAccount"/>.</param>
+        /// <returns>The <see cref="TransactionInstruction"/>.</returns>
+        public TransactionInstruction SetReferrerMemory(PublicKey mangoGroup,
+            PublicKey mangoAccount, PublicKey owner, PublicKey referrerMemory, PublicKey referrerMangoAccount,
+            PublicKey payer)
+            => SetReferrerMemory(ProgramIdKey, mangoGroup, mangoAccount, owner, referrerMemory, referrerMangoAccount,
+                payer);
+
+        /// <summary>
+        /// Initialize a new <see cref="TransactionInstruction"/> for the <see cref="MangoProgramInstructions.Values.SetReferrerMemory"/> method.
+        /// </summary>
+        /// <param name="programIdKey">The program id.</param>
+        /// <param name="mangoGroup">The mango group.</param>
+        /// <param name="mangoAccount">The mango account.</param>
+        /// <param name="owner">The mango account owner.</param>
+        /// <param name="referrerMemory">The referrer memory PDA.</param>
+        /// <param name="referrerMangoAccount">The referrer's mango account.</param>
+        /// <param name="payer">The payer of the rent for the new <see cref="ReferrerMemoryAccount"/>.</param>
+        /// <returns>The <see cref="TransactionInstruction"/>.</returns>
+        public static TransactionInstruction SetReferrerMemory(PublicKey programIdKey, PublicKey mangoGroup,
+            PublicKey mangoAccount, PublicKey owner, PublicKey referrerMemory, PublicKey referrerMangoAccount,
+            PublicKey payer)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.ReadOnly(mangoGroup, false),
+                AccountMeta.ReadOnly(mangoAccount, false),
+                AccountMeta.ReadOnly(owner, true),
+                AccountMeta.Writable(referrerMemory, false),
+                AccountMeta.ReadOnly(referrerMangoAccount, false),
+                AccountMeta.Writable(payer, true),
+                AccountMeta.ReadOnly(SystemProgram.ProgramIdKey, false),
+            };
+            return new TransactionInstruction
+            {
+                ProgramId = programIdKey,
+                Keys = keys,
+                Data = MangoProgramData.EncodeSetReferrerMemoryData()
+            };
+
+        }
+
+        /// <summary>
+        /// Initialize a new <see cref="TransactionInstruction"/> for the <see cref="MangoProgramInstructions.Values.RegisterReferrerId"/> method.
+        /// </summary>
+        /// <param name="mangoGroup">The mango group.</param>
+        /// <param name="referrerIdRecord">The referrer id record.</param>
+        /// <param name="referrerMangoAccount">The referrer's mango account.</param>
+        /// <param name="payer">The payer.</param>
+        /// <param name="referrerId">The referrer id.</param>
+        /// <returns>The <see cref="TransactionInstruction"/>.</returns>
+        public TransactionInstruction RegisterReferrerId(PublicKey mangoGroup,
+            PublicKey referrerIdRecord, PublicKey referrerMangoAccount,
+            PublicKey payer, string referrerId)
+            => RegisterReferrerId(ProgramIdKey, mangoGroup, referrerIdRecord, referrerMangoAccount,
+                payer, referrerId);
+
+        /// <summary>
+        /// Initialize a new <see cref="TransactionInstruction"/> for the <see cref="MangoProgramInstructions.Values.RegisterReferrerId"/> method.
+        /// </summary>
+        /// <param name="programIdKey">The program id.</param>
+        /// <param name="mangoGroup">The mango group.</param>
+        /// <param name="referrerIdRecord">The referrer id record.</param>
+        /// <param name="referrerMangoAccount">The referrer's mango account.</param>
+        /// <param name="payer">The payer.</param>
+        /// <param name="referrerId">The referrer id.</param>
+        /// <returns>The <see cref="TransactionInstruction"/>.</returns>
+        public static TransactionInstruction RegisterReferrerId(PublicKey programIdKey, PublicKey mangoGroup,
+            PublicKey referrerIdRecord, PublicKey referrerMangoAccount, PublicKey payer, string referrerId)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.ReadOnly(mangoGroup, false),
+                AccountMeta.Writable(referrerMangoAccount, false),
+                AccountMeta.Writable(referrerIdRecord, false),
+                AccountMeta.Writable(payer, true),
+                AccountMeta.ReadOnly(SystemProgram.ProgramIdKey, false),
+            };
+            return new TransactionInstruction
+            {
+                ProgramId = programIdKey,
+                Keys = keys,
+                Data = MangoProgramData.EncodeRegisterReferrerIdData(referrerId)
+            };
+
+        }
+
+        /// <summary>
+        /// Derives the <see cref="PublicKey"/> of a <see cref="ReferrerMemoryAccount"/>.
+        /// </summary>
+        /// <param name="mangoAccount">The mango account.</param>
+        /// <returns>The derived <see cref="PublicKey"/> if it was found, otherwise null.</returns>
+        public PublicKey DeriveReferrerMemory(PublicKey mangoAccount)
+        {
+            return MangoUtils.DeriveReferrerMemory(ProgramIdKey, mangoAccount);
+        }
+
+        /// <summary>
+        /// Derives the <see cref="PublicKey"/> of a <see cref="ReferrerMemoryAccount"/>.
+        /// </summary>
+        /// <param name="referrerId">The referrer id.</param>
+        /// <returns>The derived <see cref="PublicKey"/> if it was found, otherwise null.</returns>
+        public PublicKey DeriveReferrerIdRecord(string referrerId)
+        {
+            if (ProgramIdKey == DevNetProgramIdKeyV3)
+            {
+                return MangoUtils.DeriveReferrerPda(ProgramIdKey, Constants.DevNetMangoGroup, referrerId);
+            }
+
+            return MangoUtils.DeriveReferrerPda(ProgramIdKey, Constants.MangoGroup, referrerId);
+        }
+
+        /// <summary>
         /// Derives the <see cref="PublicKey"/> of an <see cref="AdvancedOrdersAccount"/>.
         /// </summary>
         /// <param name="mangoAccount">The mango account.</param>
         /// <returns>The derived <see cref="PublicKey"/> if it was found, otherwise null.</returns>
         public PublicKey DeriveAdvancedOrdersAccountAddress(PublicKey mangoAccount)
         {
-            if (ProgramIdKey == MainNetProgramIdKeyV3)
-            {
-                return MangoUtils.DeriveAdvancedOrdersAccountAddress(ProgramIdKey, mangoAccount);
-            }
-            else if (ProgramIdKey == DevNetProgramIdKeyV3)
-            {
-                return MangoUtils.DeriveAdvancedOrdersAccountAddress(ProgramIdKey, mangoAccount);
-            }
-
             return MangoUtils.DeriveAdvancedOrdersAccountAddress(ProgramIdKey, mangoAccount);
         }
 
@@ -1575,10 +1686,7 @@ namespace Solnet.Mango
         /// <returns>The derived <see cref="PublicKey"/> if it was found, otherwise null.</returns>
         public PublicKey DeriveMangoAccountAddress(PublicKey owner, ulong accountNumber)
         {
-            if(ProgramIdKey == MainNetProgramIdKeyV3)
-            {
-                return MangoUtils.DeriveMangoAccountAddress(ProgramIdKey, Constants.MangoGroup, owner, accountNumber);
-            } else if(ProgramIdKey == DevNetProgramIdKeyV3)
+            if(ProgramIdKey == DevNetProgramIdKeyV3)
             {
                 return MangoUtils.DeriveMangoAccountAddress(ProgramIdKey, Constants.DevNetMangoGroup, owner, accountNumber);
             }
@@ -1688,6 +1796,12 @@ namespace Solnet.Mango
                     break;
                 case MangoProgramInstructions.Values.SetDelegate:
                     MangoProgramData.DecodeSetDelegateData(decodedInstruction, keys, keyIndices);
+                    break;
+                case MangoProgramInstructions.Values.SetReferrerMemory:
+                    MangoProgramData.DecodeSetReferrerMemoryData(decodedInstruction, keys, keyIndices);
+                    break;
+                case MangoProgramInstructions.Values.RegisterReferrerId:
+                    MangoProgramData.DecodeRegisterReferrerIdData(decodedInstruction, data, keys, keyIndices);
                     break;
             }
 

--- a/Solnet.Mango/MangoProgramData.cs
+++ b/Solnet.Mango/MangoProgramData.cs
@@ -8,6 +8,7 @@ using Solnet.Wallet;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Text;
 
 namespace Solnet.Mango
 {
@@ -626,7 +627,7 @@ namespace Solnet.Mango
         {
             byte[] data = new byte[36];
             data.WriteU32((uint)MangoProgramInstructions.Values.AddMangoAccountInfo, MangoProgramLayouts.MethodOffset);
-            byte[] encodedInfo = Serialization.EncodeBincodeString(info);
+            var encodedInfo = Encoding.UTF8.GetBytes(info);
             data.WriteSpan(encodedInfo, MangoProgramLayouts.MangoAccountInfoOffset);
             return data;
         }
@@ -644,7 +645,7 @@ namespace Solnet.Mango
             decodedInstruction.Values.Add("Mango Group", keys[keyIndices[0]]);
             decodedInstruction.Values.Add("Mango Account", keys[keyIndices[1]]);
             decodedInstruction.Values.Add("Owner", keys[keyIndices[2]]);
-            (string accountInfo, _) = data.DecodeBincodeString(MangoProgramLayouts.MangoAccountInfoOffset);
+            var accountInfo = Encoding.UTF8.GetString(data.GetSpan(MangoProgramLayouts.MangoAccountInfoOffset, Constants.InfoLength)).Trim('\0');
             decodedInstruction.Values.Add("Account Info", accountInfo);
         }
 
@@ -994,6 +995,68 @@ namespace Solnet.Mango
             decodedInstruction.Values.Add("Mango Account", keys[keyIndices[1]]);
             decodedInstruction.Values.Add("Owner", keys[keyIndices[2]]);
             decodedInstruction.Values.Add("Delegate", keys[keyIndices[3]]);
+        }
+
+        /// <summary>
+        /// Encodes the <see cref="TransactionInstruction"/> data for the <see cref="MangoProgramInstructions.Values.SetReferrerMemory"/> method.
+        /// </summary>
+        /// <returns>The encoded data.</returns>
+        internal static byte[] EncodeSetReferrerMemoryData()
+        {
+            byte[] data = new byte[4];
+            data.WriteU32((uint)MangoProgramInstructions.Values.SetReferrerMemory, MangoProgramLayouts.MethodOffset);
+            return data;
+        }
+
+        /// <summary>
+        /// Decodes the instruction instruction data  for the <see cref="MangoProgramInstructions.Values.SetReferrerMemory"/> method
+        /// </summary>
+        /// <param name="decodedInstruction">The decoded instruction to add data to.</param>
+        /// <param name="keys">The account keys present in the transaction.</param>
+        /// <param name="keyIndices">The indices of the account keys for the instruction as they appear in the transaction.</param>
+        internal static void DecodeSetReferrerMemoryData(DecodedInstruction decodedInstruction, IList<PublicKey> keys,
+            byte[] keyIndices)
+        {
+            decodedInstruction.Values.Add("Mango Group", keys[keyIndices[0]]);
+            decodedInstruction.Values.Add("Mango Account", keys[keyIndices[1]]);
+            decodedInstruction.Values.Add("Owner", keys[keyIndices[2]]);
+            decodedInstruction.Values.Add("Referrer Memory", keys[keyIndices[3]]);
+            decodedInstruction.Values.Add("Referrer Mango Account", keys[keyIndices[4]]);
+            decodedInstruction.Values.Add("Payer", keys[keyIndices[5]]);
+            decodedInstruction.Values.Add("System Program", keys[keyIndices[6]]);
+        }
+
+        /// <summary>
+        /// Encodes the <see cref="TransactionInstruction"/> data for the <see cref="MangoProgramInstructions.Values.RegisterReferrerId"/> method.
+        /// </summary>
+        /// <param name="referrerId">The referrer id.</param>
+        /// <returns>The encoded data.</returns>
+        internal static byte[] EncodeRegisterReferrerIdData(string referrerId)
+        {
+            byte[] data = new byte[36];
+            data.WriteU32((uint)MangoProgramInstructions.Values.RegisterReferrerId, MangoProgramLayouts.MethodOffset);
+            var encodedInfo = Encoding.UTF8.GetBytes(referrerId);
+            data.WriteSpan(encodedInfo, MangoProgramLayouts.MangoAccountInfoOffset);
+            return data;
+        }
+
+        /// <summary>
+        /// Decodes the instruction instruction data  for the <see cref="MangoProgramInstructions.Values.RegisterReferrerId"/> method
+        /// </summary>
+        /// <param name="decodedInstruction">The decoded instruction to add data to.</param>
+        /// <param name="data">The instruction data to decode.</param>
+        /// <param name="keys">The account keys present in the transaction.</param>
+        /// <param name="keyIndices">The indices of the account keys for the instruction as they appear in the transaction.</param>
+        internal static void DecodeRegisterReferrerIdData(DecodedInstruction decodedInstruction, ReadOnlySpan<byte> data,
+            IList<PublicKey> keys, byte[] keyIndices)
+        {
+            decodedInstruction.Values.Add("Mango Group", keys[keyIndices[0]]);
+            decodedInstruction.Values.Add("Referrer Mango Account", keys[keyIndices[1]]);
+            decodedInstruction.Values.Add("Referrer Id Record", keys[keyIndices[2]]);
+            decodedInstruction.Values.Add("Payer", keys[keyIndices[3]]);
+            decodedInstruction.Values.Add("System Program", keys[keyIndices[4]]);
+            var accountInfo = Encoding.UTF8.GetString(data.GetSpan(MangoProgramLayouts.MangoAccountInfoOffset, Constants.InfoLength)).Trim('\0');
+            decodedInstruction.Values.Add("Referrer Id", accountInfo);
         }
     }
 }

--- a/Solnet.Mango/MangoProgramInstructions.cs
+++ b/Solnet.Mango/MangoProgramInstructions.cs
@@ -43,7 +43,9 @@ namespace Solnet.Mango
             { Values.CreateMangoAccount, "Create Mango Account" },
             { Values.UpgradeMangoAccountV0V1, "Upgrade Mango Account V0V1" },
             { Values.CancelPerpOrdersSide, "Cancel Perp Orders Side" },
-            { Values.SetDelegate, "Set Delegate"}
+            { Values.SetDelegate, "Set Delegate"},
+            { Values.SetReferrerMemory, "Set Referrer Memory" },
+            { Values.RegisterReferrerId, "Register Referrer Id" }
         };
 
         /// <summary>
@@ -180,6 +182,16 @@ namespace Solnet.Mango
             /// Set an alternative authority/signer for mango account transactions.
             /// </summary>
             SetDelegate = 58,
+
+            /// <summary>
+            /// Sets the account's referrer memory.
+            /// </summary>
+            SetReferrerMemory = 62,
+
+            /// <summary>
+            /// Registers a referrer id.
+            /// </summary>
+            RegisterReferrerId = 63,
         };
     }
 }

--- a/Solnet.Mango/MangoUtils.cs
+++ b/Solnet.Mango/MangoUtils.cs
@@ -89,6 +89,47 @@ namespace Solnet.Mango
         }
 
         /// <summary>
+        /// Derives the <see cref="PublicKey"/> of a referrer memory account.
+        /// </summary>
+        /// <param name="programIdKey">The program id key.</param>
+        /// <param name="mangoAccount">The mango account.</param>
+        /// <returns>The derived <see cref="PublicKey"/> if it was found, otherwise null.</returns>
+        public static PublicKey DeriveReferrerMemory(PublicKey programIdKey, PublicKey mangoAccount)
+        {
+            bool success = AddressExtensions.TryFindProgramAddress(new List<byte[]>() { 
+                mangoAccount, 
+                Encoding.UTF8.GetBytes("ReferrerMemory") 
+            }, programIdKey, out byte[] referrerMemory, out _);
+
+            return success ? new(referrerMemory) : null;
+        }
+
+        /// <summary>
+        /// Derives the <see cref="PublicKey"/> of a referrer pda.
+        /// </summary>
+        /// <param name="programIdKey">The program id key.</param>
+        /// <param name="mangoGroup">The mango group.</param>
+        /// <param name="referrerId">The referrer id.</param>
+        /// <returns>The derived <see cref="PublicKey"/> if it was found, otherwise null.</returns>
+        public static PublicKey DeriveReferrerPda(PublicKey programIdKey, PublicKey mangoGroup, string referrerId)
+        {
+            byte[] buffer = new byte[Constants.InfoLength];
+            byte[] encoded = Encoding.UTF8.GetBytes(referrerId);
+            if (encoded.Length > Constants.InfoLength)
+                throw new ArgumentException($"referrer id is too long, must be less or equal than {Constants.InfoLength} bytes",
+                    nameof(referrerId));
+            encoded.CopyTo(buffer, 0);
+
+            bool success = AddressExtensions.TryFindProgramAddress(new List<byte[]>() {
+                mangoGroup,
+                Encoding.UTF8.GetBytes("ReferrerIdRecord"),
+                buffer
+            }, programIdKey, out byte[] referrerIdRecord, out _);
+
+            return success ? new(referrerIdRecord) : null;
+        }
+
+        /// <summary>
         /// Splits the open orders funds.
         /// </summary>
         /// <param name="openOrdersAccount">The open orders account.</param>

--- a/Solnet.Mango/Models/Enums/DataType.cs
+++ b/Solnet.Mango/Models/Enums/DataType.cs
@@ -54,5 +54,15 @@ namespace Solnet.Mango.Models
         /// An advanced orders account for advanced order types such as conditional trigger orders.
         /// </summary>
         AdvancedOrders = 9,
+
+        /// <summary>
+        /// The referrer memory account.
+        /// </summary>
+        ReferrerMemory = 10,
+
+        /// <summary>
+        /// The referrer id record.
+        /// </summary>
+        ReferrerIdRecord = 11
     }
 }

--- a/Solnet.Mango/Models/MangoAccount.cs
+++ b/Solnet.Mango/Models/MangoAccount.cs
@@ -1143,11 +1143,7 @@ namespace Solnet.Mango.Models
             {
                 clientOrderIds.Add(clientOrderIdsBytes.GetU64(i * sizeof(ulong)));
             }
-
-            var accountInfoLength = span.GetU64(Layout.InfoOffset);
-            if (accountInfoLength > Constants.InfoLength)
-                accountInfoLength = Constants.InfoLength;
-            
+                        
             return new MangoAccount
             {
                 Metadata = MetaData.Deserialize(span.Slice(Layout.MetadataOffset, MetaData.Layout.Length)),
@@ -1166,7 +1162,7 @@ namespace Solnet.Mango.Models
                 MegaSerumAmount = span.GetU64(Layout.MegaSerumAmountOffset),
                 BeingLiquidated = span.GetU8(Layout.BeingLiquidatedOffset) == 1,
                 Bankrupt = span.GetU8(Layout.BankruptOffset) == 1,
-                AccountInfo = Encoding.UTF8.GetString(span.GetSpan(Layout.InfoOffset + sizeof(ulong), (int) accountInfoLength)),
+                AccountInfo = Encoding.UTF8.GetString(span.GetSpan(Layout.InfoOffset, Constants.InfoLength)).Trim('\0'),
                 OpenOrdersAccounts = new List<OpenOrdersAccount>(Constants.MaxPairs),
                 AdvancedOrdersAccount = span.GetPubKey(Layout.AdvancedOrdersOffset),
                 NotUpgradeable = span.GetU8(Layout.NotUpgradeableOffset) == 1,

--- a/Solnet.Mango/Models/ReferrerIdRecordAccount.cs
+++ b/Solnet.Mango/Models/ReferrerIdRecordAccount.cs
@@ -1,0 +1,74 @@
+﻿using Solnet.Programs.Utilities;
+using Solnet.Wallet;
+using System;
+using System.Text;
+
+namespace Solnet.Mango.Models
+{
+    /// <summary>
+    /// The referrer memory account.
+    /// </summary>
+    public class ReferrerIdRecordAccount
+    {
+        /// <summary>
+        /// The layout of the <see cref="ReferrerIdRecordAccount"/> structure.
+        /// </summary>
+        public static class Layout
+        {
+            /// <summary>
+            /// The length of the <see cref="ReferrerIdRecordAccount"/> structure.
+            /// </summary>
+            public const int Length = 72;
+
+            /// <summary>
+            /// The offset at which the metadata structure begins.
+            /// </summary>
+            internal const int MetadataOffset = 0;
+
+            /// <summary>
+            /// The offset at which the metadata structure begins.
+            /// </summary>
+            internal const int ReferrerOffset = 8;
+
+            /// <summary>
+            /// The offset at which the metadata structure begins.
+            /// </summary>
+            internal const int IdOffset = 40;
+        }
+
+        /// <summary>
+        /// The account's metadata.
+        /// </summary>
+        public MetaData Metadata;
+
+        /// <summary>
+        /// The referrer's mango account public key.
+        /// </summary>
+        public PublicKey Referrer;
+
+        /// <summary>
+        /// The referrer id.
+        /// </summary>
+        public string Id;
+
+        /// <summary>
+        /// Deserialize a byte array into a <see cref="ReferrerIdRecordAccount"/> instance.
+        /// </summary>
+        /// <param name="data">The data to deserialize into the structure.</param>
+        /// <returns>The <see cref="ReferrerIdRecordAccount"/> structure.</returns>
+        public static ReferrerIdRecordAccount Deserialize(byte[] data)
+        {
+            if (data.Length != Layout.Length)
+                throw new ArgumentException($"data length is invalid, expected {Layout.Length} but got {data.Length}");
+
+            ReadOnlySpan<byte> span = data.AsSpan();
+
+            return new ReferrerIdRecordAccount()
+            {
+                Metadata = MetaData.Deserialize(span.Slice(Layout.MetadataOffset, MetaData.Layout.Length)),
+                Referrer = span.GetPubKey(Layout.ReferrerOffset),
+                Id = Encoding.UTF8.GetString(span.GetSpan(Layout.IdOffset, Constants.InfoLength)).Trim('\0'),
+            };
+        }
+    }
+}

--- a/Solnet.Mango/Models/ReferrerMemoryAccount.cs
+++ b/Solnet.Mango/Models/ReferrerMemoryAccount.cs
@@ -1,0 +1,62 @@
+﻿using Solnet.Programs.Utilities;
+using Solnet.Wallet;
+using System;
+
+namespace Solnet.Mango.Models
+{
+    /// <summary>
+    /// The referrer memory account.
+    /// </summary>
+    public class ReferrerMemoryAccount
+    {
+        /// <summary>
+        /// The layout of the <see cref="ReferrerMemoryAccount"/> structure.
+        /// </summary>
+        public static class Layout
+        {
+            /// <summary>
+            /// The length of the <see cref="ReferrerMemoryAccount"/> structure.
+            /// </summary>
+            public const int Length = 40;
+
+            /// <summary>
+            /// The offset at which the metadata structure begins.
+            /// </summary>
+            internal const int MetadataOffset = 0;
+
+            /// <summary>
+            /// The offset at which the metadata structure begins.
+            /// </summary>
+            internal const int ReferrerOffset = 8;
+        }
+
+        /// <summary>
+        /// The account's metadata.
+        /// </summary>
+        public MetaData Metadata;
+
+        /// <summary>
+        /// The referrer's mango account public key.
+        /// </summary>
+        public PublicKey Referrer;
+
+        /// <summary>
+        /// Deserialize a byte array into a <see cref="ReferrerMemoryAccount"/> instance.
+        /// </summary>
+        /// <param name="data">The data to deserialize into the structure.</param>
+        /// <returns>The <see cref="ReferrerMemoryAccount"/> structure.</returns>
+        public static ReferrerMemoryAccount Deserialize(byte[] data)
+        {
+            if (data.Length != Layout.Length)
+                throw new ArgumentException($"data length is invalid, expected {Layout.Length} but got {data.Length}");
+
+            ReadOnlySpan<byte> span = data.AsSpan();
+
+            return new ReferrerMemoryAccount()
+            {
+                Metadata = MetaData.Deserialize(span.Slice(Layout.MetadataOffset, MetaData.Layout.Length)),
+                Referrer = span.GetPubKey(Layout.ReferrerOffset)
+            };
+        }
+    }
+}


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Feature/Hotfix | Yes| Closes #44  |

## Problem

_What problem are you trying to solve?_

Lack of the newly added referrer features
Bugs in ser/des of static length strings found in `MangoAccount`

## Solution

_How did you solve the problem?_

Added instructions, account ser/des
Fixed ser/des of static length strings by not accounting for string length u64