### PR TITLE
Fixes program pubkey in decode

### DIFF
--- a/Solnet.Mango/MangoProgram.cs
+++ b/Solnet.Mango/MangoProgram.cs
@@ -1710,7 +1710,7 @@ namespace Solnet.Mango
 
             DecodedInstruction decodedInstruction = new()
             {
-                PublicKey = DevNetProgramIdKeyV3,
+                PublicKey = MainNetProgramIdKeyV3,
                 InstructionName = MangoProgramInstructions.Names[instructionValue],
                 ProgramName = DefaultProgramName,
                 Values = new Dictionary<string, object>(),


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Hotfix | Yes| Closes #43 |

## Problem

_What problem are you trying to solve?_

The method to decode instructions was defaulting to devnet program pubkey

## Solution

_How did you solve the problem?_

Changed to default mainnet because it is a static method