### PR TITLE
More accurate TIF filtering based on snapshot timestamp instead of current time.

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Product>Solnet.Mango</Product>
-        <Version>6.0.3.3</Version>
+        <Version>6.0.3.4</Version>
         <Copyright>Copyright 2021 &#169; blockmountain</Copyright>
         <Authors>blockmountain</Authors>
         <PublisherName>blockmountain</PublisherName>

--- a/Solnet.Mango.Test/MangoClientTest.cs
+++ b/Solnet.Mango.Test/MangoClientTest.cs
@@ -582,7 +582,7 @@ namespace Solnet.Mango.Test
             Assert.IsTrue(obs.ParsedResult.Metadata.IsInitialized);
             Assert.AreEqual(DataType.Bids, obs.ParsedResult.Metadata.DataType);
             var bids = obs.ParsedResult.GetOrders();
-            Assert.AreEqual(11, bids.Count); // there's 11 orders without expiry
+            Assert.AreEqual(14, bids.Count); // there's 14 orders without expiry
             var bidsWithExpired = obs.ParsedResult.GetOrders(true);
             Assert.AreEqual(16, bidsWithExpired.Count); // there's 16 orders total including expired
         }

--- a/Solnet.Mango/Models/Matching/LeafNode.cs
+++ b/Solnet.Mango/Models/Matching/LeafNode.cs
@@ -170,14 +170,13 @@ namespace Solnet.Mango.Models.Matching
         /// <remarks>
         /// This is checked by the order's <see cref="TimeInForce"/> value.
         /// If it is equal to<see cref="byte.MinValue"/> the order never expires,
-        /// otherwise the order expires after <see cref="Timestamp"/> plus <see cref="byte.MaxValue"/> seconds.</remarks>
+        /// otherwise the order expires at <see cref="Timestamp"/> plus <see cref="byte.MaxValue"/> seconds.</remarks>
         /// </summary>
         /// <returns>true if it is valid, otherwise false.</returns>
-        public bool IsValid()
+        public bool IsValid(ulong timestamp)
         {
             var expiry = Timestamp + TimeInForce;
-            var now = (ulong) DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
-            return TimeInForce == 0 || now <= expiry;
+            return TimeInForce == 0 || timestamp < expiry;
         }
 
         /// <summary>


### PR DESCRIPTION
Filtering for expired orders based on the current time can filter out orders that may not have expired at the time that the snapshot was taken. Instead of filtering by the current time, you can filter by the last update to the book snapshot.

